### PR TITLE
updated readme for build

### DIFF
--- a/NRF_Bootloader.md
+++ b/NRF_Bootloader.md
@@ -41,7 +41,7 @@ sudo pip install nrfutil
 ### Compilation
 
 ```
-make clean;PUCKJS=1 RELEASE=1 DFU_UPDATE_BUILD=1 make
+make clean;BOARD=PUCKJS RELEASE=1 DFU_UPDATE_BUILD=1 make
 ```
 
 # Flashing

--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ See [libs/README.md](libs/README.md) for a short tutorial on how to add your own
 * Open the file `/make/common/NRF5X.make`:
     * Change all commands `python` to `python3`
 * Install the C compiler with the command `brew install armmbed/formulae/arm-none-eabi-gcc`
-* Install the nrfutil package with the command `sudo -H pip install nrfutil`
-
+* Install the nrfutil executable from the [official webiste](https://www.nordicsemi.com/Products/Development-tools/nrf-util) 
+* Make it executable with `chmod +x nrfutil` and add it to PATH.
+* Install nrf5sdk-tools with the command `nrfutil install nrf5sdk-tools`
 
 
 Using Espruino in your Projects


### PR DESCRIPTION
**NRF_Bootloader.md**

It failed the sanity check before

**README.md**

The python package _nrfutil_ is no longer maintained and not compatible with newer python versions. The official cli tool is now a standalone that can be downloaded directly from [nordicsemi](https://www.nordicsemi.com/Products/Development-tools/nrf-util).